### PR TITLE
Added filehandle fix and test to show that it is correctly seeking

### DIFF
--- a/lib/Geo/UK/Postcode/Regex.pm
+++ b/lib/Geo/UK/Postcode/Regex.pm
@@ -278,6 +278,8 @@ tie our %REGEXES, 'Geo::UK::Postcode::Regex::Hash', _fetch => sub {
 sub _outcode_data {
     my %area_districts;
 
+    # get the original position in the DATA File Handle
+    my $orig_position = tell( DATA );
     # Get outcodes from __DATA__
     while ( my $line = <DATA> ) {
         next unless $line =~ m/\w/;
@@ -290,6 +292,8 @@ sub _outcode_data {
             non_geographical => $non_geographical,
         };
     }
+    # Reset position of DATA File Handle for re-reading
+    seek DATA, $orig_position, 0;
 
     # Add in BX non-geographical outcodes
     foreach ( 1 .. 99 ) {

--- a/t/data-filehandle-multi-read.t
+++ b/t/data-filehandle-multi-read.t
@@ -14,8 +14,6 @@ use Test::More;
 use strict;
 use warnings;
 
-use Devel::Dwarn;
-
 use Geo::UK::Postcode::Regex;
 
 my $pkg = 'Geo::UK::Postcode::Regex';

--- a/t/data-filehandle-multi-read.t
+++ b/t/data-filehandle-multi-read.t
@@ -1,0 +1,83 @@
+# Error found when using Mojolicious with this application - in a pre-forking
+# environment, or a non threaded environment, the filehandle for DATA is opened
+# once, and then a reference is passed to all sub references. Obviously, after
+# that the first one to read from it will have moved the seek position in the
+# file, and so when another process reads from the file it will continue where
+# the previous one left off.
+#
+# As the contents of %OUTCODES depends on reading the DATA correctly every
+# time, this test makes sure that on subsequent reads of the data, the file is
+# read consistently from the same place.
+
+use Test::More;
+
+use strict;
+use warnings;
+
+use Devel::Dwarn;
+
+use Geo::UK::Postcode::Regex;
+
+my $pkg = 'Geo::UK::Postcode::Regex';
+
+note "checking validation - block 1";
+is_deeply $pkg->parse( 'AB11 1AA' ), {
+  area => "AB",
+  district => 11,
+  incode => "1AA",
+  outcode => "AB11",
+  partial => 0,
+  sector => 1,
+  strict => 1,
+  subdistrict => undef,
+  unit => "AA",
+  valid => 1,
+}, 'Valid Geo Postcode';
+is_deeply $pkg->parse( 'BX12 1AA' ), {
+  area => "BX",
+  district => 12,
+  incode => "1AA",
+  non_geographical => 1,
+  outcode => "BX12",
+  partial => 0,
+  sector => 1,
+  strict => 1,
+  subdistrict => undef,
+  unit => "AA",
+  valid => 1
+}, 'Valid Non-Geo Postcode';
+
+# Empty Outcodes cache - this emulates running in a preforking, non-threaded
+# environment where one of the forks has read the open filehandle, and another
+# has not.
+my $outcodes = Geo::UK::Postcode::Regex->outcodes_lookup;
+delete Geo::UK::Postcode::Regex->outcodes_lookup->{$_} for keys %$outcodes;
+
+note "checking validation - block 2";
+is_deeply $pkg->parse( 'AB11 1AA' ), {
+  area => "AB",
+  district => 11,
+  incode => "1AA",
+  outcode => "AB11",
+  partial => 0,
+  sector => 1,
+  strict => 1,
+  subdistrict => undef,
+  unit => "AA",
+  valid => 1,
+}, 'Valid Geo Postcode';
+is_deeply $pkg->parse( 'BX12 1AA' ), {
+  area => "BX",
+  district => 12,
+  incode => "1AA",
+  non_geographical => 1,
+  outcode => "BX12",
+  partial => 0,
+  sector => 1,
+  strict => 1,
+  subdistrict => undef,
+  unit => "AA",
+  valid => 1
+}, 'Valid Non-Geo Postcode';
+
+done_testing();


### PR DESCRIPTION
Error found when using Mojolicious with this application - in a pre-forking environment, or a non threaded environment, the filehandle for DATA is opened once, and then a reference is passed to all sub references. Obviously, after that the first one to read from it will have moved the seek position in the file, and so when another process reads from the file it will continue where the previous one left off.   
 
As the contents of %OUTCODES depends on reading the DATA correctly every time, this test makes sure that on subsequent reads of the data, the file is read consistently from the same place.

This PR contains the fix for seeking back to the original position of DATA, as well as a test which clears the %OUTCODES hash (via outcodes_lookup) forcing a re-read of the DATA section.
